### PR TITLE
[dependency] Bump org.apache.commons:commons-compress

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <brukernotifikasjon-schemas.version>2.5.2</brukernotifikasjon-schemas.version>
     <checker-qual.version>3.42.0</checker-qual.version>
     <classgraph.version>4.8.165</classgraph.version>
-    <commons-compress.version>1.22</commons-compress.version>
+    <commons-compress.version>1.24.0</commons-compress.version>
     <commons-cli.version>1.6.0</commons-cli.version>
     <commons-io.version>2.15.1</commons-io.version>
     <flyway.version>10.5.0</flyway.version>


### PR DESCRIPTION
Bumps org.apache.commons:commons-compress from 1.22 to 1.24.0.

---
updated-dependencies:
- dependency-name: org.apache.commons:commons-compress dependency-type: direct:production ...